### PR TITLE
add feature to replace jar after execution

### DIFF
--- a/src/javactl/executor/executor.py
+++ b/src/javactl/executor/executor.py
@@ -6,6 +6,7 @@ import re
 import time
 import getpass
 import glob
+import shutil
 from datetime import datetime, timedelta
 from mog_commons.command import execute_command, capture_command, execute_command_with_pid, pid_exists
 from mog_commons.case_class import CaseClass
@@ -99,7 +100,7 @@ class Executor(CaseClass):
 
     def execute(self, now):
         return self._execute_commands(self.setting.pre_commands, now)._execute_application(now)._execute_commands(
-            self.setting.post_commands, now)
+            self.setting.post_commands, now)._replace_jar()
 
     def _execute_application(self, now):
         if self.failed:
@@ -161,3 +162,13 @@ class Executor(CaseClass):
                         self.setting.app_setting.name, cmd, ret))
                     failed = True
         return self.copy(failed=failed)
+
+    def _replace_jar(self):
+        jar = self.setting.app_setting.jar
+        staging_jar = self.setting.app_setting.staging_jar
+
+        if jar is not None and staging_jar is not None:
+            if os.path.exists(staging_jar):
+                shutil.move(staging_jar, jar)
+
+        return self

--- a/src/javactl/setting/app_setting.py
+++ b/src/javactl/setting/app_setting.py
@@ -7,7 +7,7 @@ from javactl.util import normalize_path
 
 
 class AppSetting(CaseClass):
-    def __init__(self, name=None, home=None, jar=None, entry_point=None, command=None, pid_file=None):
+    def __init__(self, name=None, home=None, jar=None, staging_jar=None, entry_point=None, command=None, pid_file=None):
         # constraints
         assert name is not None, 'app.name is required'
         assert home is not None, 'app.home is required'
@@ -22,6 +22,7 @@ class AppSetting(CaseClass):
             ('name', name),
             ('home', home),
             ('jar', omap(normalize, jar)),
+            ('staging_jar', omap(normalize, staging_jar)),
             ('entry_point', entry_point),
             ('command', omap(normalize, command)),
             ('pid_file', omap(normalize, pid_file))

--- a/tests/resources/test_02.yml.j2
+++ b/tests/resources/test_02.yml.j2
@@ -1,0 +1,73 @@
+---
+app:
+  name: your-app
+  home: {{ tempdir }}
+  jar: bin/your-app-assembly-0.1.0.jar
+  staging_jar: bin/staging/staging-your-app-assembly-0.1.0.jar
+  pid_file: your-app.pid
+
+os:
+  user: {{ os_user }}
+  env:
+    YOUR_APP_ENV_VAR1: 12345
+    YOUR_APP_ENV_VAR2: /path/to/xxx
+
+java:
+  home: {{ curdir }}/tests/resources/mock/jdk8
+  version: 1.8
+  server: true
+  
+  memory:
+    heap_min: 64M
+    heap_max: 2G
+    metaspace_min: 1G
+    metaspace_max: 2G
+    new_min: 256M
+    new_max: 256M
+    survivor_ratio: 8
+    target_survivor_ratio: 50
+
+  jmx:
+    port: 20001
+    ssl: false
+    authenticate: false
+
+  prop:
+    file.encoding: UTF-8
+    http.port: 9000
+    http.netty.maxInitialLineLength: 8192
+    com.amazonaws.sdk.disableCertChecking: true
+
+  option:
+    - "-XX:+UseConcMarkSweepGC"
+    - "-XX:+CMSParallelRemarkEnabled"
+    - "-XX:+UseCMSInitiatingOccupancyOnly"
+    - "-XX:CMSInitiatingOccupancyFraction=70"
+    - "-XX:+ScavengeBeforeFullGC"
+    - "-XX:+CMSScavengeBeforeRemark"
+
+log:
+  console:
+    prefix: logs/console/console
+    max_size: 10M
+    backup: 10
+    preserve: 60
+
+  gc:
+    prefix: logs/gc/gc
+    max_size: 10M
+    backup: 10
+    preserve: 60
+
+  dump:
+    prefix: logs/dump
+
+  error:
+    path: logs/hs_error_pid%p.log
+
+#pre:
+#  - echo 'Pre command is now running.'
+
+#post:
+#  - echo 'Post command[0] is now running.'
+#  - echo 'Post command[1] is now running.'


### PR DESCRIPTION
Add `staging-jar` setting to deploy new jar while app is running.
This feature works as follows:

- If  both`app.jar` and `app.staging_jar` are set, replace jar file at `app.jar` with `app.staging_jar` after execution.

Motivation:

- Imagine that you run java-batch application via javactl.
- If you deploy new jar to `app.jar`, JVM class loader fails to load classes still unloaded.